### PR TITLE
fix floating number bug by moving total calculation into a function and rounding

### DIFF
--- a/js/donate/donate.js
+++ b/js/donate/donate.js
@@ -365,6 +365,12 @@ class Donate extends React.PureComponent {
     return this.state.currentIncentives.reduce((sum, ci) => sum + (+ci.amount), 0);
   }
 
+  // getTotal fixes floating point numbers appearing
+  getTotal(amount) {
+    var total = (amount || 0) - this.sumIncentives_();
+    return Math.round(total * 1e2) / 1e2;
+  }
+
   finishDisabled_() {
     const {
       amount,
@@ -603,7 +609,7 @@ class Donate extends React.PureComponent {
               currentIncentives={currentIncentives}
               deleteIncentive={this.deleteIncentive_}
               addIncentive={this.addIncentive_}
-              total={(amount || 0) - this.sumIncentives_()}
+              total={this.getTotal(amount)}
             />
             <div className={styles['finishArea']}>
               <button


### PR DESCRIPTION
This should fix floating numbers happening when using the input arrows to set an amount. 

![float](https://user-images.githubusercontent.com/916147/46220398-f3fe6600-c317-11e8-9371-b1cc6d209981.png)
